### PR TITLE
Week5 / Jeonbyeongmin

### DIFF
--- a/BOJ/13549.jeonbyeongmin.java
+++ b/BOJ/13549.jeonbyeongmin.java
@@ -1,0 +1,62 @@
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class Main {
+
+    public static final int MAX_X = 100000;
+    public static Queue<FinderInfo> queue = new LinkedList<>();
+    public static boolean[] visited = new boolean[MAX_X + 1];
+
+    public static void main(String[] args) {
+
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+        int K = sc.nextInt();
+
+        System.out.print(bfs(new FinderInfo(N, 0), K));
+
+        sc.close();
+    }
+
+    static int bfs(FinderInfo finderInfo, int targetX) {
+
+        if (finderInfo.x == targetX)
+            return 0;
+
+        queue.add(finderInfo);
+
+        while (!queue.isEmpty()) {
+            FinderInfo current = queue.poll();
+
+            if (current.x == targetX)
+                return current.sec;
+
+            move(current.x * 2, current.sec);
+            move(current.x - 1, current.sec + 1);
+            move(current.x + 1, current.sec + 1);
+
+        }
+
+        return -1;
+    }
+
+    static void move(int nextX, int nextSec) {
+        if (0 <= nextX && nextX <= MAX_X && !visited[nextX]) {
+            queue.add(new FinderInfo(nextX, nextSec));
+            visited[nextX] = true;
+        }
+    }
+
+    static class FinderInfo {
+        int x;
+        int sec;
+
+        public FinderInfo(int x, int sec) {
+            this.x = x;
+            this.sec = sec;
+        }
+    }
+
+}

--- a/CSES/road-construction.jeonbyeongmin.java
+++ b/CSES/road-construction.jeonbyeongmin.java
@@ -1,0 +1,76 @@
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+/**
+ * Hello world!
+ *
+ */
+public class App {
+
+    public static int n;
+    public static int m;
+    public static int[] parent;
+    public static int[] rank;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        parent = new int[n + 1];
+        rank = new int[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            rank[i] = 1;
+            parent[i] = -1;
+        }
+
+        int max = 1;
+        int cc = n;
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if (find(a) != find(b)) {
+                max = Math.max(union(a, b), max);
+                cc--;
+            }
+
+            bw.write(cc + " " + max + "\n");
+        }
+
+        bw.close();
+
+    }
+
+    public static int find(int x) {
+        if (parent[x] != -1) {
+            return parent[x] = find(parent[x]);
+        }
+        return x;
+    }
+
+    public static int union(int a, int b) {
+        a = find(a);
+        b = find(b);
+
+        int temp = 0;
+        if (rank[a] < rank[b]) {
+            temp = rank[a];
+            rank[a] = rank[b];
+            rank[b] = temp;
+        }
+
+        parent[b] = a;
+        rank[a] += rank[b];
+
+        return rank[a];
+    }
+
+}

--- a/CSES/road-construction.jeonbyeongmin.java
+++ b/CSES/road-construction.jeonbyeongmin.java
@@ -26,7 +26,7 @@ public class App {
 
         for (int i = 1; i <= n; i++) {
             rank[i] = 1;
-            parent[i] = -1;
+            parent[i] = i;
         }
 
         int max = 1;
@@ -50,7 +50,7 @@ public class App {
     }
 
     public static int find(int x) {
-        if (parent[x] != -1) {
+        if (parent[x] != x) {
             return parent[x] = find(parent[x]);
         }
         return x;
@@ -60,17 +60,15 @@ public class App {
         a = find(a);
         b = find(b);
 
-        int temp = 0;
         if (rank[a] < rank[b]) {
-            temp = rank[a];
-            rank[a] = rank[b];
-            rank[b] = temp;
+            parent[a] = b;
+            rank[b] += rank[a];
+        } else {
+            parent[b] = a;
+            rank[a] += rank[b];
         }
 
-        parent[b] = a;
-        rank[a] += rank[b];
-
-        return rank[a];
+        return Math.max(rank[a], rank[b]);
     }
 
 }

--- a/Programmers/2021 Dev-Matching/다단계칫솔판매.jeonbyeongmin.js
+++ b/Programmers/2021 Dev-Matching/다단계칫솔판매.jeonbyeongmin.js
@@ -1,0 +1,44 @@
+const TOOTHBRUSH_PRICE = 100;
+const MIN_PROFIT = 1;
+
+function solution(enroll, referral, seller, amount) {
+  const money = amount.map((number) => number * TOOTHBRUSH_PRICE);
+
+  const sellerInfo = {};
+
+  enroll.map((person, idx) => {
+    sellerInfo[person] = {
+      referral: referral[idx],
+      totalProfit: 0,
+    };
+  });
+
+  seller.map((person, idx) => {
+    let restProfit = money[idx];
+    let restReferralProfit = 0;
+    let currentPerson = person;
+
+    while (currentPerson !== "-" && restProfit !== 0) {
+      const devidedProfit = Math.floor(restProfit / 10);
+
+      // devidedProfit 이 MIN_PROFIT 보다 크거나 같을 땐 추천인한테 돈 뜯기고
+      if (devidedProfit >= MIN_PROFIT) {
+        sellerInfo[currentPerson].totalProfit += restProfit - devidedProfit;
+        restReferralProfit = devidedProfit;
+      }
+      // devidedProfit 이 MIN_PROFIT 보다 작을 땐 추천인한테 돈 안주고 낼름한다.
+      else {
+        sellerInfo[currentPerson].totalProfit += restProfit;
+        restReferralProfit = 0;
+      }
+      currentPerson = sellerInfo[currentPerson].referral;
+      restProfit = restReferralProfit;
+    }
+  });
+
+  const result = enroll.map((person) => {
+    return sellerInfo[person].totalProfit;
+  });
+
+  return result;
+}


### PR DESCRIPTION
### 📋  문제
[백준 - Gold5 - 숨바꼭질3](https://www.acmicpc.net/problem/13549)

수빈이가 동생이랑 숨바꼭질을 하는데 본인이 술래다. 근데 수빈이는 초인적인 힘을 가지고 있어서 무려 순간이동이 가능한댄다 😂. 순간이동은 시간이 들지 않지만 자신의 위치에서 2*x 위치밖에 가지 못한다. 그래서 그냥 걷기도 해야하는데 걷는 것은 한칸에 1초가 걸린다. 수빈이가 동생을 가장 빠르게 찾는 시간을 찾는 문제이다.

### 💡 아이디어
- BFS로 해결할 수 있다.

### 🧞‍♂️ 해결 방법
- BFS로 해결했다. 근데 문제는 움직이는 비용이 똑같지 않다. (간선의 가중치가 다른 것) 
- 그래서 단순한 BFS를 쓴다고 해도 순간이동을 먼저하느냐 걷는 것을 먼저하는냐에 따라 동생을 찾는 시간이 달라진다.
- *2 -1 +1 순으로 큐에 넣어야 정답으로 채점된다. 0-1 bfs라고 하던데 더 공부가 필요할 것 같다.


### ⏱ 시간복잡도
- O(V+E)

---


### 📋  문제
[CSES - ?? - Road Construction](https://cses.fi/problemset/task/1676)

도시 사이에 도로를 만드는 과정에서 집합의 개수와 가장 큰 집합에 속하는 도시의 수를 구해야하는 유니온파인드 문제이다.


### 💡 아이디어
- 전형적인 유니온 파인드 문제라고 생각하고 접근하였다.

### 🧞‍♂️ 해결 방법
- 처음에는 일반적인 유니온 파인드 문제라고 생각했지만 반복문을 도는 와중에 유니온 파인드의 정보를 출력해야한다.
- 그래서 반복문 안에서 반복문을 하나 더 돌려 배열의 상황을 파악하여 출력하였지만
- 이 방법은 비용이 굉장히 많이 들었다.
- 시간 초과 문제를 해결하려면 O(nlogn) 즉 유니온 파인드 과정중에 상수 시간으로 해결해야 했다.
- 즉 유니온 파인드 연산 중에 반복문을 돌릴 수 없기 때문에 배열을 하나 더 만들어서
- 가장 큰 도시를 가지는 parent를 기록해야한다.
- 게다가 이 문제는 자바로 푼다면 시간이 굉징히 팍팍하다.
- BufferedReader BufferedWriter 를 사용해야하고 swap같은 쓸모없는 연산도 줄여야 겨우 통과한다.

### ⏱ 시간복잡도
- O(nlogn)

---


### 📋  문제
[프로래머스 - Lv.3 - 다단계 칫솔 판매](https://programmers.co.kr/learn/courses/30/lessons/77486)

다단계로 칫솔을 판매하는데 자신의 parent 에게 수익의 10%를 때어줘야 한다. 판매 수익이 주어졌을 때 전체 판매원의 총 수익을 결정하는 문제이다.

### 💡 아이디어
- 문제를 보자마자 판매원들의 객체를 만들어야겠다는 생각을 했다.
- `sellerInfo { name: { referral, totalProfit } }` 구조로 생성하였다.
- 자바스크립트의 경우 이렇게 객체로 만들어두면 계산하기 굉장히 편리한 것 같다.

### 🧞‍♂️ 해결 방법
- 객체로 만든 순간 해결하는 방법은 굉장히 간단하다.
- 그냥 문제에서 제시한 순서대로 seller를 반복문으로 돌면서 seller의 referral 를, referral의 referral을 반복해서 profit을 계산하고 sellerInfo의 totalProfit을 갱신해주면 된다.

### ⏱ 시간복잡도
- O(n^2) 

---
