### PR TITLE
week07/chs

### DIFF
--- a/Programmers/연습문제/체육복.chs.go
+++ b/Programmers/연습문제/체육복.chs.go
@@ -1,0 +1,31 @@
+func solution(n int, lost []int, reserve []int) int {
+    uniforms := make([]int, n, n)
+	answer := 0
+
+	for i, _ := range uniforms {
+		uniforms[i] = 1
+	}
+	for _, index := range lost {
+		uniforms[index-1]--
+    }
+	for _, index := range reserve {
+		uniforms[index-1]++
+	}
+	
+	for i := 0; i < n; i++ {
+		if i > 0 && uniforms[i] == 0 && uniforms[i-1] > 1 {
+			uniforms[i]++
+			uniforms[i-1]--
+		}
+		if i < n-1 && uniforms[i] == 0 && uniforms[i+1] > 1 {
+			uniforms[i]++
+			uniforms[i+1]--
+		}
+	}
+	for _, value := range uniforms {
+		if value > 0 {
+			answer++
+		}
+	}
+	return answer
+}

--- a/Programmers/월간 코드 챌린지 시즌3/금과은운반하기.chs.go
+++ b/Programmers/월간 코드 챌린지 시즌3/금과은운반하기.chs.go
@@ -1,0 +1,55 @@
+import (
+    "math"
+)
+// 총 광물의 양, 전달 횟수, 적재량을 받아
+// 전달할 수 있는 최대 광물의 양을 구하는 함수
+func GetMaxMineral(mineral int64 , move_cnt int64 , weight int64) int64 {
+    if mineral < move_cnt * weight {
+        return mineral
+    } else {
+        return move_cnt * weight
+    }
+}
+func Min(a int64, b int64) int64 {
+    if a<b {
+        return a
+    }
+    return b
+}
+
+func solution(a int, b int, g []int, s []int, w []int, t []int) int64 {
+    answer := int64(math.Pow(10,9)) * int64(math.Pow(10,5)) * 4
+    start := int64(0)
+    end := answer
+    for start <= end{
+        mid := int64((start+end)/2)
+        var gold,silver,total int64= 0,0,0
+        
+        for i:= 0 ; i < len(g) ; i ++ {
+            i_gold, i_silver, i_weight, i_time :=int64(g[i]),int64(s[i]),int64(w[i]),int64(t[i])
+            mv := mid / (i_time * 2) // 왕복 가능 횟수
+            if mid % (i_time*2) >= i_time {
+                mv ++
+            }
+            // 최대로 전달할 수 있는 금, 은, 토탈값을 구한다.
+            gold += GetMaxMineral(i_gold, mv, i_weight)
+            silver += GetMaxMineral(i_silver,mv,i_weight)
+            // 토탈값은 같은 도시에서 금과 은을 모두 운반하는 경우 mv카운트가 겹치기때문에 
+            // 체크해야할 조건이다.
+            if (i_gold + i_silver < mv * i_weight){
+                total += i_gold + i_silver
+            } else {
+                total += mv * i_weight 
+            }
+        }   
+        // 금과 은이 모두 기준치이상이며 토탈값 또한 만족할 때
+        if gold >= int64(a) && silver >= int64(b) && total >= int64(a + b){
+            end = mid - 1 // mid~end 를 날림
+            answer = Min(answer,mid)
+            
+        } else { // 만족 X
+            start = mid + 1 // start ~ mid 를 날림
+        }
+    }
+    return answer
+}

--- a/Programmers/해시/위장.chs.go
+++ b/Programmers/해시/위장.chs.go
@@ -1,0 +1,11 @@
+func solution(clothes [][]string) int {
+    category := make(map[string]int, 0)
+    for _, item := range(clothes) {
+        category[item[1]] ++
+    }
+    sum := 1
+    for _, num := range(category){
+        sum *= num+1
+    }
+    return sum-1
+}


### PR DESCRIPTION
### 📋  문제
[프로그래머스 월간 코드 챌린지 3 - Lv.3 - 금과 은 운반하기](https://programmers.co.kr/learn/courses/30/lessons/86053?)

문제 요약 

금 a, 은 b 만큼 얻어야 하는 상황이다.
각 도시별 금과 은 적재량, 교통 비용, 적재량이 주어질 때 금과 은을 a, b 만큼 얻는 최소한의 교통 비용을 구하시오.

### 💡 아이디어
- 교통 비용을 +1 씩하며 탐색하기에는 너무나 많은 시간이 걸렸다.
- Best case  ~ Worst case 의 범위를 두고 이분 탐색을 하기로 했다.
  - Best case    : a,b == 0 인 경우 -> 0
  - Worst case : a,b == 10^9, 도시 개수 10^5, 왕복 2, 금과 은 따로 구할 때 2 -> 2 x 2 x 10^9 x 10^5 = 2^2 x 10^14

### 🧞‍♂️ 해결 방법
- start = 0 , end = worstcase , mid = (start+end)/2 로 두고 `이분 탐색`을 한다.
- 모든 도시를 돌며 최대로 적재할 수 있는 `금과 은의 양을 누적`한다.
- 금과 은이 같은 도시에서 추출될 경우를 고려한 `total`을 계산한다.
  - 금과 은은 도시에서의 `최대 적재량을 각각 구하기 때문에 겹치는 경우 값이 달라진다.`
  - 최대금 + 최대은과 전달횟수 * 최대적재량 중 더 작은 것을 total에 누적한다.
- 모든 도시를 돌며 `금의 양, 은의 양, total을 구했을 때 모두 a, b, a+b 이상`이라면 금과 은을 충분히 가져온 것이다.
  - end = mid-1 로 이동하여 mid ~ end 를 날려 다음 반복 때 mid 값을 감소시킨다.
- 그렇지 않다면 금과 은을 충분히 가져오지 못한 것이다.
  - start = mid+1 로 이동하여 start ~ mid 를 날려 다음 반복 때 mid 값을 증가시킨다.
- start > end 가 되는 시점에 반복을 종료한다.
### ⏱ 시간복잡도
- O(n log T) T = worst case ( 2^2 * 10^14 )
---
### 📋  문제
[프로그래머스 - Lv.2 - 위장](https://programmers.co.kr/learn/courses/30/lessons/42578)

문제 요약
옷과 종류 쌍 배열이 주어질 때 최소한 한 개이상 입을 수 있는 경우의 수

### 💡 아이디어
- 카테고리별 옷의 개수를 세고 안입는 경우 + 1을 해주었다.
- 모두 곱한 뒤 모두 안 입는 경우 1개를 뺐다.

### 🧞‍♂️ 해결 방법
- map[string]int 로 map["겉옷"] ++ 와 같이 카테고리별 옷의 개수를 세주었다.
- 다시 카테고리를 모두 순회하며 값들을 +1해주고 모두 곱해서 누적했다.
- 누적값 - 1을 반환했다.

### ⏱ 시간복잡도
- O(n)

---
