### PR TITLE
week09/chs

### DIFF
--- a/BOJ/18429.chs.go
+++ b/BOJ/18429.chs.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strconv"
+	"fmt"
+	"strings"
+	"bufio"
+	"os"
+)
+
+var kit int
+var loss int
+var count int
+var kitEff []int
+var visit []bool
+func main(){
+	count = 0
+
+	reader := bufio.NewScanner(os.Stdin)	
+	visit = make([]bool,kit)
+	fmt.Scanf("%d %d", &kit, &loss)
+	reader.Scan() 
+	slice := strings.Split(reader.Text(), " ")
+	for _, str := range slice {
+		eff,_ :=strconv.Atoi(str)
+		kitEff = append(kitEff, eff - loss ) 
+		visit = append(visit, false)
+	}
+	backTracking(500, 0)
+	fmt.Println(count)
+}
+
+func backTracking(currW int, depth int){
+	if depth == kit-1 {
+		count ++
+	}
+	for i := 0 ; i < len(visit); i ++ {
+		if !visit[i] {
+			visit[i] = true
+			if currW+kitEff[i] >= 500 {
+				backTracking(currW + kitEff[i], depth+1)
+				visit[i] = false
+			} else { visit[i] = false}
+  
+		}
+	}
+	
+}


### PR DESCRIPTION
### 📋  문제
[백준 18429 - Silver3 - 근손실](https://www.acmicpc.net/problem/18429)

하루에 하나씩 사용할 수 있는 운동 키트 N개, 하루 근손실량 K, 키트 별 근성장량 N개가 주어질 때 시작 중량 500이하로 떨어지지 않는 운동 방법 경우의 수를 구하라.

### 💡 아이디어
- 500 이하로 떨어지는 경로의 노드를 가지치기한다.

### 🧞‍♂️ 해결 방법
- **근성장량 - 근손실량**을 `kitEff`에 저장한다.
- 방문 확인용 visit을 false로 초기화한 뒤 backTracking 함수를 시작한다.
- backTracking 함수는 키트를 사용했을 때 중량이 500을 넘어야만 계속해서 호출되고
- 모든 기구를 사용했을 시 -> **depth가 N-1**인 경우 count를 올려준다.
- backTracking 함수가 종료된 후 count를 출력해준다.

### ⏱ 시간복잡도
- O(N!)

---
